### PR TITLE
fix reference to use auto-selected Faster 3G setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Hacker News readers as [Progressive Web Apps](https://g.co/ProgressiveWebApps). 
 * Repo: https://github.com/insin/react-hn
 * Lighthouse: 100/100
 
-**Emerging Markets**
+*Emerging Markets*
 
 * WPT: https://www.webpagetest.org/result/170420_95_53G/
 * Time To Interactive: 6.2s
 
-**Fast 3G**
+*Fast 3G*
 
 * WPT: https://www.webpagetest.org/result/170328_4T_471cf99ca38b890fc687d1ca25e2260f/
 * Time To Interactive: 4.2s
@@ -26,12 +26,12 @@ Hacker News readers as [Progressive Web Apps](https://g.co/ProgressiveWebApps). 
 * Repo: https://github.com/kristoferbaxter/preact-hn
 * Lighthouse: 100/100
 
-**Emerging Markets**
+*Emerging Markets*
 
 * WPT: https://www.webpagetest.org/result/170420_73_54G/
 * Time To Interactive: 2.4s
 
-**Fast 3G**
+*Fast 3G*
 
 * WPT: https://www.webpagetest.org/result/170328_SX_2b62ae440379075b887f472c02a3e0a3/
 * Time To Interactive: 1.78s
@@ -42,12 +42,12 @@ Hacker News readers as [Progressive Web Apps](https://g.co/ProgressiveWebApps). 
 * Repo: https://github.com/sveltejs/svelte-hackernews
 * Lighthouse: 100/100
 
-**Emerging Markets**
+*Emerging Markets*
 
 * WPT: https://www.webpagetest.org/result/170420_9K_54X/
 * Time To Interactive: 4.9s
 
-**Fast 3G**
+*Fast 3G*
 
 * WPT: https://www.webpagetest.org/result/170420_XE_54S/
 * Time To Interactive: 3.7s
@@ -58,12 +58,12 @@ Hacker News readers as [Progressive Web Apps](https://g.co/ProgressiveWebApps). 
 * Repo: https://github.com/vuejs/vue-hackernews-2.0
 * Lighthouse: 93/100
 
-**Emerging Markets**
+*Emerging Markets*
 
 * WPT: https://www.webpagetest.org/result/170413_KY_7F4/
 * Time To Interactive: 2.9s
 
-**Fast 3G**
+*Fast 3G*
 
 * WPT: https://www.webpagetest.org/result/170420_MK_556/
 * Time To Interactive: 2.4s
@@ -74,12 +74,12 @@ Hacker News readers as [Progressive Web Apps](https://g.co/ProgressiveWebApps). 
 * Repo: https://github.com/housseindjirdeh/angular2-hn
 * Lighthouse: 100/100
 
-**Emerging Markets**
+*Emerging Markets*
 
 * WPT: https://www.webpagetest.org/result/170420_46_67R/
 * Time To Interactive: 5.8s
 
-**Fast 3G**
+*Fast 3G*
 
 * WPT: https://www.webpagetest.org/result/170328_N6_761d4f12fce28adc5163a3d056ce0af6/
 * Time To Interactive: 3.48s
@@ -90,12 +90,12 @@ Hacker News readers as [Progressive Web Apps](https://g.co/ProgressiveWebApps). 
 * Repo: https://github.com/WebReflection/viper-news
 * Lighthouse: 100/100
 
-**Emerging Markets**
+*Emerging Markets*
 
 * WPT: https://www.webpagetest.org/result/170412_R2_1K0J/
 * Time To Interactive: 1.9s
 
-**Fast 3G**
+*Fast 3G*
 
 * WPT: https://www.webpagetest.org/result/170420_Y0_5KR/
 * Time To Interactive: 1.6s

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Each implementation must include:
 * Views: Top Stories, New, Show, Ask, Jobs & threaded Comments
 * App must be a [Progressive Web App](https://g.co/ProgressiveWebApps)
 * App must score over a 90/100 using [Lighthouse](https://github.com/GoogleChrome/lighthouse)
-* App must become interactive in under 5 seconds on a Moto G4 over 3G. Use [WebPageTest](https://www.webpagetest.org/easy) using the auto-selected Moto G4 + Emerging Market setting to check.
+* App must become interactive in under 5 seconds on a Moto G4 over 3G. Use [WebPageTest](https://www.webpagetest.org/easy) using the auto-selected Moto G4 + Faster 3G setting to check.
 * App must use the [Application Shell](https://developers.google.com/web/fundamentals/architecture/app-shell) pattern to instantly load the skeleton of the UI on repeat visits
-* App must do its best to work cross-browser 
+* App must do its best to work cross-browser
 
 Optionally:
 
@@ -76,4 +76,3 @@ Optionally:
 ## License
 
 Each implementation preserves the license noted in the linked to applications.
-

--- a/README.md
+++ b/README.md
@@ -8,49 +8,97 @@ Hacker News readers as [Progressive Web Apps](https://g.co/ProgressiveWebApps). 
 
 * Live: https://react-hn.appspot.com
 * Repo: https://github.com/insin/react-hn
-* WPT: https://www.webpagetest.org/result/170328_4T_471cf99ca38b890fc687d1ca25e2260f/
-* Time to interactive: 4.2s
 * Lighthouse: 100/100
+
+**Emerging Markets**
+
+* WPT: https://www.webpagetest.org/result/170420_95_53G/
+* Time To Interactive: 6.2s
+
+**Fast 3G**
+
+* WPT: https://www.webpagetest.org/result/170328_4T_471cf99ca38b890fc687d1ca25e2260f/
+* Time To Interactive: 4.2s
 
 ### Preact
 
 * Live: https://hn.kristoferbaxter.com/
 * Repo: https://github.com/kristoferbaxter/preact-hn
-* WPT: https://www.webpagetest.org/result/170328_SX_2b62ae440379075b887f472c02a3e0a3/
-* Time to interactive (beta): 1.78s
 * Lighthouse: 100/100
+
+**Emerging Markets**
+
+* WPT: https://www.webpagetest.org/result/170420_73_54G/
+* Time To Interactive: 2.4s
+
+**Fast 3G**
+
+* WPT: https://www.webpagetest.org/result/170328_SX_2b62ae440379075b887f472c02a3e0a3/
+* Time To Interactive: 1.78s
 
 ### Svelte
 
 * Live: https://svelte-hn.now.sh/
 * Repo: https://github.com/sveltejs/svelte-hackernews
-* WPT: https://www.webpagetest.org/result/170326_WA_W1F/
-* Time to interactive (beta): 4.5s
 * Lighthouse: 100/100
+
+**Emerging Markets**
+
+* WPT: https://www.webpagetest.org/result/170420_9K_54X/
+* Time To Interactive: 4.9s
+
+**Fast 3G**
+
+* WPT: https://www.webpagetest.org/result/170420_XE_54S/
+* Time To Interactive: 3.7s
 
 ### Vue.js
 
 * Live: https://vue-hn.now.sh/
 * Repo: https://github.com/vuejs/vue-hackernews-2.0
-* WPT: https://www.webpagetest.org/result/170413_KY_7F4/
-* Time to interactive: 2.9s
 * Lighthouse: 93/100
+
+**Emerging Markets**
+
+* WPT: https://www.webpagetest.org/result/170413_KY_7F4/
+* Time To Interactive: 2.9s
+
+**Fast 3G**
+
+* WPT: https://www.webpagetest.org/result/170420_MK_556/
+* Time To Interactive: 2.4s
 
 ### Angular
 
 * Live: https://angular2-hn.firebaseapp.com/
 * Repo: https://github.com/housseindjirdeh/angular2-hn
-* WPT: https://www.webpagetest.org/result/170328_N6_761d4f12fce28adc5163a3d056ce0af6/
-* Time to interactive: 3.48s
 * Lighthouse: 100/100
+
+**Emerging Markets**
+
+* WPT: https://www.webpagetest.org/result/170420_46_67R/
+* Time To Interactive: 5.8s
+
+**Fast 3G**
+
+* WPT: https://www.webpagetest.org/result/170328_N6_761d4f12fce28adc5163a3d056ce0af6/
+* Time To Interactive: 3.48s
 
 ### viperHTML
 
 * Live: https://viperhtml-164315.appspot.com/
 * Repo: https://github.com/WebReflection/viper-news
-* WPT: https://www.webpagetest.org/result/170412_R2_1K0J/
-* Time To Interactive (alpha): 1.9s
 * Lighthouse: 100/100
+
+**Emerging Markets**
+
+* WPT: https://www.webpagetest.org/result/170412_R2_1K0J/
+* Time To Interactive: 1.9s
+
+**Fast 3G**
+
+* WPT: https://www.webpagetest.org/result/170420_Y0_5KR/
+* Time To Interactive: 1.6s
 
 ## Specification
 


### PR DESCRIPTION
Just noticed that the higher TTI numbers you were noticing with Angular 2 HN last night (https://www.webpagetest.org/result/170413_25_8MA/) was with Emerging Markets :)

Changed the reference in the README to use the Faster 3G setting instead. However do you think EM should be the requirement instead? Unfortunately my app (and I think a few of the others 🤔 ) will most probably have TTI > 5s under that condition.
