### PR TITLE
add jekyll-app-engine plugin

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -21,4 +21,5 @@ gem "minima", "~> 2.0"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"
+   gem 'jekyll-app-engine'
 end

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
       pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
+    jekyll-app-engine (0.1.0)
     jekyll-feed (0.9.2)
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.0)
@@ -46,6 +47,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (= 3.3.1)
+  jekyll-app-engine
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
 
@@ -53,4 +55,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -31,6 +31,11 @@ collections:
 markdown: kramdown
 gems:
   - jekyll-feed
+  - jekyll-app-engine
 exclude:
   - Gemfile
   - Gemfile.lock
+app_engine:
+  runtime: go
+  api_version: go1
+  default_expiration: 300s

--- a/site/init.go
+++ b/site/init.go
@@ -1,0 +1,8 @@
+// Included to enable deployment to Google App Engine
+package hello
+
+import (
+)
+
+func init() {
+}


### PR DESCRIPTION
Adds `jekyll-app-engine` gem which sets up `app.yaml` after every build.

Once installed with `bundle install`: 

1. `jekyll build` in the `/site` directory
2. `app.yaml` will be created within `_site` output directory. Move it up to root (where `_config.yml`  lives)
3. `gcloud app deploy` (if you have App Engine CLI set up)

Once we include CI into the process (I'll get to it sometime this week hopefully), this whole process should be automated but for now we'll have to do a couple of steps :)