### PR TITLE
remove app engine gem, add runtime skip cleanup step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.3.3
 before_install:
   - cd site 
-  - echo $super_secret_password | gpg --passphrase-fd 0 service-acc.json.gpg
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo $super_secret_password | gpg --passphrase-fd 0 service-acc.json.gpg; fi'
 script: 
   - bundle exec jekyll build
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: ruby
 rvm:
   - 2.3.3
-
 before_install:
   - cd site 
   - echo $super_secret_password | gpg --passphrase-fd 0 service-acc.json.gpg
 script: 
   - bundle exec jekyll build
-  - mv _site/app.yaml .
 deploy:
   provider: gae
+  skip_cleanup: true
   keyfile: service-acc.json
   project: hnpwa-prod
 env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,13 +9,3 @@ If your Hacker News implementation meets the [specifications](https://github.com
 ## Updating the site
 
 We're exploring using wildcards for our handlers in the `appl.yaml` file but if you add a static file or asset to the repository, you'll have to include it in file in the meantime.
-
-## Pull Requests
-
-If the Travis CI build for your PR fails with the following error: 
-
-`gpg: decryption failed: bad key`
-
-`The command "echo $super_secret_password | gpg --passphrase-fd 0 service-acc.json.gpg" failed and exited with 2 during .`
-
-This is most likely due to the security restrictions Travis CI has in place with pull requests (see [here](https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions)). The following build once your PR is merged in should be accurate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+Thank you for your interest in contributing!
+
+## Adding a Hacker News implementation
+
+If your Hacker News implementation meets the [specifications](https://github.com/tastejs/hacker-news-pwas#specification), don't hesitate to put up a PR for it!
+
+## Updating the site
+
+We're exploring using wildcards for our handlers in the `appl.yaml` file but if you add a static file or asset to the repository, you'll have to include it in file in the meantime.
+
+## Pull Requests
+
+If the Travis CI build for your PR fails with the following error: 
+
+`gpg: decryption failed: bad key`
+
+`The command "echo $super_secret_password | gpg --passphrase-fd 0 service-acc.json.gpg" failed and exited with 2 during .`
+
+This is most likely due to the security restrictions Travis CI has in place with pull requests (see [here](https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions)). The following build once your PR is merged in should be accurate.

--- a/site/Gemfile
+++ b/site/Gemfile
@@ -21,5 +21,4 @@ gem "minima", "~> 2.0"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"
-   gem 'jekyll-app-engine'
 end

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -17,7 +17,6 @@ GEM
       pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
-    jekyll-app-engine (0.1.0)
     jekyll-feed (0.9.2)
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.0)
@@ -47,7 +46,6 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (= 3.3.1)
-  jekyll-app-engine
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -29,7 +29,6 @@ collections:
 markdown: kramdown
 gems:
   - jekyll-feed
-  - jekyll-app-engine
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/site/app.yaml
+++ b/site/app.yaml
@@ -1,0 +1,62 @@
+---
+runtime: go
+api_version: go1
+default_expiration: 300s
+handlers:
+- url: "/"
+  static_files: _site/index.html
+  upload: _site/index.html
+- url: "/assets/styles/main.css"
+  static_files: _site/assets/styles/main.css
+  upload: _site/assets/styles/main.css
+- url: "/feed.xml"
+  static_files: _site/feed.xml
+  upload: _site/feed.xml
+- url: "/assets/favicon.ico"
+  static_files: _site/assets/favicon.ico
+  upload: _site/assets/favicon.ico
+- url: "/assets/images/angular-logo.svg"
+  static_files: _site/assets/images/angular-logo.svg
+  upload: _site/assets/images/angular-logo.svg
+- url: "/assets/images/angular2hn-mobile.png"
+  static_files: _site/assets/images/angular2hn-mobile.png
+  upload: _site/assets/images/angular2hn-mobile.png
+- url: "/assets/images/favicon.png"
+  static_files: _site/assets/images/favicon.png
+  upload: _site/assets/images/favicon.png
+- url: "/assets/images/hnpwa-logo.png"
+  static_files: _site/assets/images/hnpwa-logo.png
+  upload: _site/assets/images/hnpwa-logo.png
+- url: "/assets/images/preact-logo.svg"
+  static_files: _site/assets/images/preact-logo.svg
+  upload: _site/assets/images/preact-logo.svg
+- url: "/assets/images/preacthn-mobile.png"
+  static_files: _site/assets/images/preacthn-mobile.png
+  upload: _site/assets/images/preacthn-mobile.png
+- url: "/assets/images/react-logo.svg"
+  static_files: _site/assets/images/react-logo.svg
+  upload: _site/assets/images/react-logo.svg
+- url: "/assets/images/reacthn-mobile.png"
+  static_files: _site/assets/images/reacthn-mobile.png
+  upload: _site/assets/images/reacthn-mobile.png
+- url: "/assets/images/svelte-logo.svg"
+  static_files: _site/assets/images/svelte-logo.svg
+  upload: _site/assets/images/svelte-logo.svg
+- url: "/assets/images/sveltehn-mobile.png"
+  static_files: _site/assets/images/sveltehn-mobile.png
+  upload: _site/assets/images/sveltehn-mobile.png
+- url: "/assets/images/viperhtml-logo.svg"
+  static_files: _site/assets/images/viperhtml-logo.svg
+  upload: _site/assets/images/viperhtml-logo.svg
+- url: "/assets/images/viperhtml-mobile.png"
+  static_files: _site/assets/images/viperhtml-mobile.png
+  upload: _site/assets/images/viperhtml-mobile.png
+- url: "/assets/images/vue-logo.svg"
+  static_files: _site/assets/images/vue-logo.svg
+  upload: _site/assets/images/vue-logo.svg
+- url: "/assets/images/vuehn-mobile.png"
+  static_files: _site/assets/images/vuehn-mobile.png
+  upload: _site/assets/images/vuehn-mobile.png
+- url: "/assets/manifest.json"
+  static_files: _site/assets/manifest.json
+  upload: _site/assets/manifest.json


### PR DESCRIPTION
Apologies for having to have to submit another PR for this :(

The deploy step was unfortunately failing after you merged in my last PR (https://travis-ci.org/tastejs/hacker-news-pwas/builds/232316582). For some reason the `jekyll-app-engine` plugin wasn't created the `app.yaml` file correctly. I opened an issue for this [here](https://github.com/jamesramsay/jekyll-app-engine/issues/9). In the meantime however, I removed it and manually added the `app.yaml` file with the generated handlers. 

Tested this on a local repository and it seems to work (https://hnpwatest.appspot.com/).

A couple of things however:

1. If someone adds a static file/asset they'll have to update the `app.yaml` file accordingly. This isn't too big of a deal I think (and to be honest using wildcards will probably make more sense there, we can open a separate issue for that)
2. To set up a pipeline for App Engine with Travis CI, we need to make sure the service account file associated with the project is encrypted (which I did). Unfortunately, [**pull requests sent from forked repositories do not have access to encrypted data**](https://docs.travis-ci.com/user/pull-requests#Pull-Requests-and-Security-Restrictions). This means that anyone putting up a PR from a forked repo -- the build will fail at that script (meaning for every PR coming from a forked repo: the build will show that it fails). I can't think of a way around this unfortunately 🤔 . However, the following build once a PR is merged in should be accurate.