### PR TITLE
Fix issue with Service Worker not working in prod

### DIFF
--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -15,11 +15,7 @@
 
     {% include footer.html %}
 
-    {% for static_file in site.static_files %}
-      {% if static_file.path == '/service-worker.js' %}
-        {% include service-worker-register.html %}
-      {% endif %}
-    {% endfor %}
+    {% include service-worker-register.html %}
 
   </body>
 


### PR DESCRIPTION
This was due to the template checking for the service worker file before compiling the static HTML and because we're generating the service worker after the build step in CI it wasn't including the template to instantiate the service worker.