### PR TITLE
fixes animation for buttons

### DIFF
--- a/site/_layouts/home.html
+++ b/site/_layouts/home.html
@@ -66,8 +66,8 @@ layout: default
           </dl>
 
           <div class="flex justify-center justify-start-l ">
-            <a class="f7 f6-m fw5 fw6-m tracked bg-orange link grow br-pill dib ph3 ph4-l pv2 black" href={{ app.app-link }}>VIEW APP</a>
-            <a class="f7 f6-m fw5 fw6-m tracked bg-orange link grow br-pill dib ph3 ph4-l pv2 black ml2" href={{ app.github-link }}>SOURCE CODE</a>
+            <a class="f7 f6-m fw5 fw6-m tracked bg-orange no-underline grow br-pill dib ph3 ph4-l pv2 near-black" href={{ app.app-link }}>VIEW APP</a>
+            <a class="f7 f6-m fw5 fw6-m tracked bg-orange no-underline grow br-pill dib ph3 ph4-l pv2 near-black ml2" href={{ app.github-link }}>SOURCE CODE</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
view app and source code buttons had both `link` and `grow` classes on it. `link` has a conflicting CSS transition so the animation was broken. Replaced `link` with `no-underline` and softened the colour a bit.