### PR TITLE
avoid uploading extra files to GAE

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -33,6 +33,12 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - vendor
+  - init.go
+  - app.yaml
+  - package.json
+  - service-acc.json.gpg
+  - sw-precache-config.js
+  - node_modules
 app_engine:
   runtime: go
   api_version: go1

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -39,7 +39,3 @@ exclude:
   - service-acc.json.gpg
   - sw-precache-config.js
   - node_modules
-app_engine:
-  runtime: go
-  api_version: go1
-  default_expiration: 300s

--- a/site/app.yaml
+++ b/site/app.yaml
@@ -2,27 +2,37 @@
 runtime: go
 api_version: go1
 default_expiration: 300s
+
 handlers:
 - url: /
   static_files: _site/index.html
   upload: _site/index\.html
+  secure: always
+  http_headers:
+    X-UA-Compatible: "IE=edge"
 
 - url: /(.*)
   static_files: _site/\1
   upload: _site/(.*)
+  secure: always
 
 skip_files:
-- ^_apps/.*
-- ^_contributors/.*
-- ^_includes/.*
-- ^_layouts/.*
-- ^_sass/.*
-- ^assets/.*
-- ^node_modules/.*
+- ^_apps
+- ^_contributors
+- ^_includes
+- ^_layouts
+- ^_sass
+- ^assets
+- ^node_modules
 - ^_config\.yml$
 - ^Gemfile.*
 - ^package\.json$
 - ^sw-precache-config\.js$
 - ^(.*/)?.*\.md$
 - ^(.*/)?.*\.gpg$
+
+- ^(.*/)?#.*#$
+- ^(.*/)?.*~$
+- ^(.*/)?.*\.py[co]$
+- ^(.*/)?.*/RCS/.*$
 - ^(.*/)?\..*$

--- a/site/app.yaml
+++ b/site/app.yaml
@@ -10,3 +10,19 @@ handlers:
 - url: /(.*)
   static_files: _site/\1
   upload: _site/(.*)
+
+skip_files:
+- ^_apps/.*
+- ^_contributors/.*
+- ^_includes/.*
+- ^_layouts/.*
+- ^_sass/.*
+- ^assets/.*
+- ^node_modules/.*
+- ^_config\.yml$
+- ^Gemfile.*
+- ^package\.json$
+- ^sw-precache-config\.js$
+- ^(.*/)?.*\.md$
+- ^(.*/)?.*\.gpg$
+- ^(.*/)?\..*$


### PR DESCRIPTION
There are several files uploaded to GAE that -I think- are not necessary. The consequence of this PR is that downloading the source from GAE using `appcfg.py` will result in getting the `_site` folder & `app.yaml` only (didn't check downloading because I don't have `appcfg`). This should be fine because the full source code is here...

To check the skipped files I deploy using this command:

```
gcloud app deploy --project project-id --verbosity=info
```

But this forces me to deploy to see these affected file & I didn't look for any other way!

This PR will also prevent serving files from the `node_modules` that is in the `_site` folder (Copied by `Jekyll` which I didn't notice when proposing my previous PR!) See: https://hnpwa.com/node_modules/got/index.js

Ref: https://cloud.google.com/appengine/docs/standard/python/config/appref#skip_files