### PR TITLE
update hnpwa-vue perf numbers

### DIFF
--- a/site/_apps/hnpwa-vue.txt
+++ b/site/_apps/hnpwa-vue.txt
@@ -8,20 +8,20 @@ libraries:
     - name: 'vue-pwa-boilerplate'
 module-bundling: 'Webpack'
 service-worker: 'Application Shell with SWPrecachePlugin'
-perfomance-patterns: 'preload/prefetch resources, lazy loaded routes, dns-prefetch'
+perfomance-patterns: 'preload/prefetch resources, client-side data preload, lazy loaded routes, dns-prefetch'
 server-side-rendering: 'None'
 api: 'Node-hnapi (unofficial)'
 hosting: 'Github Pages'
 authors:
     - name: 'Anubhav'
 lighthouse: '91/100'
-interactive-em: '5.6s'
-interactive-faster-3g: '4.4s'
-lighthouse-link: https://www.webpagetest.org/lighthouse.php?test=170711_ZB_a240146243587fb5c61017b0d9b588c3&run=2
-wpt-em-link: https://www.webpagetest.org/result/170711_CR_7d6edbaf1cfeb460324bc4ad71ba129d/
-wpt-faster-3g-link: https://www.webpagetest.org/result/170711_ZB_a240146243587fb5c61017b0d9b588c3/
+interactive-em: '4.3s'
+interactive-faster-3g: '3.4s'
+lighthouse-link: https://www.webpagetest.org/lighthouse.php?test=170717_C8_230384878d6c07f66bb59cf11f15ad24&run=3
+wpt-em-link: https://www.webpagetest.org/result/170717_TC_8b6a7c9d33d6687172ff9104a78cbae3/
+wpt-faster-3g-link: https://www.webpagetest.org/result/170717_C8_230384878d6c07f66bb59cf11f15ad24/
 image: /assets/images/hnpwa-vue.png
-app-link: https://anubhav7495.github.io/hnpwa-vue
+app-link: https://anubhav7495.github.io/hnpwa-vue/
 github-link: https://github.com/anubhav7495/hnpwa-vue
 framework-link: https://vuejs.org/
 ---


### PR DESCRIPTION
Hi everyone,

Did some hacks and managed to get hnpwa-vue Interactive times much lower on both Faster 3G and 3G_EM.

[LightHouse Link](https://www.webpagetest.org/lighthouse.php?test=170717_C8_230384878d6c07f66bb59cf11f15ad24&run=3)

[Faster 3G](https://www.webpagetest.org/result/170717_C8_230384878d6c07f66bb59cf11f15ad24/)

[3G Emerging Markets](https://www.webpagetest.org/result/170717_TC_8b6a7c9d33d6687172ff9104a78cbae3/)

Thanks.