### PR TITLE
Remove Preact library from the next-hnpwa

### DIFF
--- a/site/_apps/next-hnpwa.txt
+++ b/site/_apps/next-hnpwa.txt
@@ -4,7 +4,6 @@ title:  'HNPWA with Next.js'
 github-title: 'codebusking/next-hnpwa-guide-kit'
 libraries: 
     - name: 'Next.js'
-    - name: 'Preact'
     - name: 'firebase-hackernews'
 module-bundling: 'Webpack'
 service-worker: 'Application Shell + data caching with Workbox'


### PR DESCRIPTION
Hi!

Because it is [no longer used](https://github.com/codebusking/next-hnpwa-guide-app/commit/7130c036462ad908c30f94b15652d57400863b4f#diff-5d0c276360a637d1b787a57760665fbe).