### PR TITLE
Fixed typo in webcomponents-hn

### DIFF
--- a/site/_apps/webcomponents-hn.txt
+++ b/site/_apps/webcomponents-hn.txt
@@ -5,7 +5,7 @@ github-title: 'dsolimando/hnpwa-mobileelements'
 library: 'No Libray'
 module-bundling: 'No module bundling'
 service-worker: 'Application Shell'
-perfomance-patterns: 'HTTP/2, Gzip static assets', CDN
+perfomance-patterns: 'HTTP/2, Gzip static assets, CDN'
 server-side-rendering: 'yes'
 api: 'Node-hnapi (unofficial)'
 hosting: 'Google Compute Engine'


### PR DESCRIPTION
Fixes Breaking of website due to typo in `webcomponents-hn.txt`