### PR TITLE
New API deploy config

### DIFF
--- a/api/.firebaserc
+++ b/api/.firebaserc
@@ -1,0 +1,6 @@
+{
+  "projects": {
+    "prod": "hnpwa-coffee",
+    "staging": "hnpwa-api"
+  }
+}

--- a/api/firebase.json
+++ b/api/firebase.json
@@ -3,6 +3,10 @@
     "public": "dist/public",
     "rewrites": [
       {
+        "source": "/v0**",
+        "function": "api0"
+      },
+      {
         "source": "/v0/**",
         "function": "api0"
       }

--- a/api/functions/package.json
+++ b/api/functions/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "firebase-admin": "^5.8.1",
     "firebase-functions": "^0.8.1",
-    "hnpwa-api": "^0.1.2"
+    "hnpwa-api": "^0.2.0"
   },
   "private": true
 }

--- a/api/package.json
+++ b/api/package.json
@@ -20,7 +20,7 @@
     "@types/fs-extra": "^5.0.0",
     "firebase-tools": "^3.17.4",
     "fs-extra": "^5.0.0",
-    "hnpwa-api": "^0.1.5",
+    "hnpwa-api": "^0.2.0",
     "typescript": "^2.7.2"
   }
 }

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -2277,9 +2277,9 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
-hnpwa-api@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/hnpwa-api/-/hnpwa-api-0.1.5.tgz#cd4b2b3608aaaba5bd88a731a1bfa114862890a0"
+hnpwa-api@^0.1.9:
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/hnpwa-api/-/hnpwa-api-0.1.9.tgz#4929f114c1e00bee1bb5f129a4425a966adf3040"
   dependencies:
     "@types/compression" "0.0.33"
     "@types/cors" "^2.8.1"


### PR DESCRIPTION
This change modifies the Firebase config re-write rules so that trailing slashes and non-trailing slashes work appropriately.

```json
    "rewrites": [
      {
        "source": "/v0**",
        "function": "api0"
      },
      {
        "source": "/v0/**",
        "function": "api0"
      }
    ]
```