### PR TITLE
Fixes footer styling

### DIFF
--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -8,8 +8,8 @@
     {% for contributor in sortedContributors %}
       {% assign loopindex = forloop.index | modulo: 2 %}
       {% if loopindex == 1 %}
-        <div class="flex flex-column items-center mv3 w-100 w-50-m w-auto-l">
-          <div>
+        <div class="flex flex-column items-center w-100 w-50-m w-20-l">
+          <div class="mv4">
             <a class="link" href={{ contributor.link }}>
               <img src={{ contributor.image }} class="grow-large pa1 ba b--black-10 br-100 h3 w3" alt={{ contributor.name }}>
             </a>
@@ -17,7 +17,7 @@
             <h4 class="f6 mid-gray fw4 ttu tracked">{{ contributor.name }}</h4>
           </div>
       {% else %}
-          <div>
+          <div class="mv4">
             <a class="link" href={{ contributor.link }}>
               <img src={{ contributor.image }} class="grow-large pa1 ba b--black-10 br-100 h3 w3" alt={{ contributor.name }}>
             </a>


### PR DESCRIPTION
Footer looks a bit off, this fixes it :)

#### Before

<img width="1440" alt="screen shot 2018-07-15 at 11 58 51 am" src="https://user-images.githubusercontent.com/12476932/42735672-7a898b82-8826-11e8-95ab-f931c107bc49.png">

#### After

![footer](https://user-images.githubusercontent.com/12476932/42735676-7f6b3cf4-8826-11e8-9619-558a4ba5bd83.gif)

Can view here: https://footerender.surge.sh/

Still need to come up with a better way to weigh authors/implementations. Will be in a future PR!